### PR TITLE
Implement basic reporting webapp

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,81 @@
+(function(){
+const main = document.querySelector('main');
+let kpiData = JSON.parse(localStorage.getItem('kpiData') || '[]');
+
+function updateChart(){
+    const ctx = document.getElementById('kpi-chart').getContext('2d');
+    if(window.kpiChart) window.kpiChart.destroy();
+    window.kpiChart = new Chart(ctx, {
+        type: 'line',
+        data: {
+            labels: kpiData.map((_,i)=>`Semana ${i+1}`),
+            datasets: [{label:'KPI', data:kpiData, borderColor:'#3498db'}]
+        }
+    });
+}
+
+function saveReport(){
+    const reports = JSON.parse(localStorage.getItem('reports')||'[]');
+    const num = reports.length + 1;
+    const reportHtml = document.body.innerHTML;
+    reports.push({num, html: reportHtml, date: new Date().toISOString()});
+    localStorage.setItem('reports', JSON.stringify(reports));
+    const kpi = parseFloat(prompt('Ingrese valor KPI de la semana', '0'));
+    if(!isNaN(kpi)) {
+        kpiData.push(kpi);
+        localStorage.setItem('kpiData', JSON.stringify(kpiData));
+        updateChart();
+    }
+    alert('Reporte guardado #' + num);
+}
+
+function createBlock(type){
+    const section = document.createElement('section');
+    section.className = 'card editable';
+    let inner = '';
+    switch(type){
+        case 'text': inner = '<p contenteditable="true">Nuevo texto...</p>'; break;
+        case 'image': inner = '<input type="file" accept="image/*">'; break;
+        case 'kpi': inner = '<p contenteditable="true">KPI:</p>'; break;
+        case 'table': inner = '<table><tr><td contenteditable="true"></td></tr></table>'; break;
+        case 'note': inner = '<p contenteditable="true">Nota...</p>'; break;
+    }
+    section.innerHTML = inner + '<button class="delete-block">Eliminar</button>';
+    main.appendChild(section);
+}
+
+function setupTemplateManager(){
+    document.getElementById('edit-templates-btn').addEventListener('click', ()=>{
+        const type = prompt('Tipo de bloque (text, image, kpi, table, note)');
+        if(type) createBlock(type);
+    });
+    main.addEventListener('click', e=>{
+        if(e.target.classList.contains('delete-block')){
+            e.target.parentElement.remove();
+        }
+    });
+}
+
+function loadReports(){
+    const btn = document.getElementById('view-reports-btn');
+    btn.addEventListener('click', ()=>{
+        const reports = JSON.parse(localStorage.getItem('reports')||'[]');
+        const list = reports.map(r=>`#${r.num} - ${new Date(r.date).toLocaleDateString()}`).join('\n');
+        alert('Reportes guardados:\n'+list);
+    });
+}
+
+function generatePDF(){
+    const { jsPDF } = window.jspdf;
+    const doc = new jsPDF();
+    doc.html(document.body, { callback: doc=>{ doc.save('reporte.pdf'); } });
+}
+
+document.getElementById('save-report').addEventListener('click', saveReport);
+
+document.getElementById('generate-pdf').addEventListener('click', generatePDF);
+
+setupTemplateManager();
+loadReports();
+updateChart();
+})();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="manifest" href="manifest.json">
+    <link rel="stylesheet" href="style.css">
+    <title>Report de Avance</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+</head>
+<body>
+    <nav id="main-menu">
+        <button id="edit-templates-btn">Editar Plantillas</button>
+        <button id="fill-report-btn">Llenar Reporte</button>
+        <button id="view-reports-btn">Ver Reportes</button>
+    </nav>
+    <main>
+        <section id="report-cover" class="card" contenteditable="true">
+            <h2>Portada del Reporte</h2>
+            <p>Escriba aquí la información inicial del reporte...</p>
+        </section>
+        <section id="kpi-section" class="card">
+            <h2>Indicadores</h2>
+            <canvas id="kpi-chart" height="100"></canvas>
+        </section>
+        <section id="summary-section" class="card">
+            <h2>Resumen Semanal</h2>
+            <table id="summary-table">
+                <thead>
+                    <tr><th>Actividad</th><th>Estado</th><th>Notas</th></tr>
+                </thead>
+                <tbody>
+                    <tr><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td></tr>
+                </tbody>
+            </table>
+        </section>
+        <section id="photos-section" class="card">
+            <h2>Fotografías</h2>
+            <input type="file" id="photo-input" multiple accept="image/*">
+            <div id="photo-list"></div>
+        </section>
+    </main>
+    <button id="save-report">Guardar Reporte</button>
+    <button id="generate-pdf">Generar PDF</button>
+    <script src="app.js"></script>
+</body>
+</html>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,9 @@
+{
+    "name": "Reporte de Avance",
+    "short_name": "Reporte",
+    "start_url": "./index.html",
+    "display": "standalone",
+    "background_color": "#ffffff",
+    "theme_color": "#3498db",
+    "icons": []
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,74 @@
+body {
+    font-family: Arial, Helvetica, sans-serif;
+    margin: 0;
+    padding: 0;
+    background: #f5f5f5;
+}
+
+#main-menu {
+    display: flex;
+    justify-content: center;
+    gap: 10px;
+    background: #2c3e50;
+    padding: 1rem;
+}
+
+#main-menu button {
+    background: #3498db;
+    color: #fff;
+    border: none;
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+#main-menu button:hover {
+    background: #2980b9;
+}
+
+main {
+    max-width: 900px;
+    margin: auto;
+    padding: 1rem;
+}
+
+.card {
+    background: #fff;
+    padding: 1rem;
+    margin-bottom: 1rem;
+    border-radius: 6px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+#photo-list img {
+    max-width: 100px;
+    margin: 5px;
+}
+
+@media (max-width: 600px) {
+    #main-menu {
+        flex-direction: column;
+    }
+}
+
+button#save-report, button#generate-pdf {
+    margin: 0.5rem;
+    padding: 0.5rem 1rem;
+    background: #27ae60;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+button#generate-pdf {
+    background: #e67e22;
+}
+
+button#save-report:hover {
+    background: #1e8449;
+}
+
+button#generate-pdf:hover {
+    background: #d35400;
+}


### PR DESCRIPTION
## Summary
- add HTML interface for creating and viewing reports
- style page with responsive card layout
- implement basic template and report management in JS
- save data to localStorage and create PDF export
- provide manifest for future PWA support

## Testing
- `npm test` *(fails: Could not find package.json)*
- `pytest` *(no tests discovered)*

------
https://chatgpt.com/codex/tasks/task_e_684c8aea0d4083269d6e499f2370b799