### PR TITLE
Implement basic reporting webapp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# reportedeavance
+# Reporte de Avance Semanal
+
+Herramienta web ligera para crear y administrar reportes semanales de obra. Se pueden definir plantillas, llenar reportes con fotos y graficar KPI históricos. Los datos se almacenan en `localStorage`.
+
+Abre `index.html` con una extensión como **Live Server** para usar la aplicación de forma local.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,413 @@
+class ReportApp {
+    constructor() {
+        this.currentView = 'home-view';
+        this.currentTemplateId = null;
+        this.currentFilledReportId = null;
+        this.db = { templates: [], filledReports: [], kpiData: [] };
+        this.jsPDF = window.jspdf.jsPDF;
+        document.addEventListener('DOMContentLoaded', () => this.init());
+        this.currentPhotos = [];
+    }
+
+    init() {
+        this.loadData();
+        this.showView('home-view');
+        this.updateChart();
+    }
+
+    showView(viewId) {
+        document.querySelectorAll('.view').forEach(v => v.classList.remove('active'));
+        document.getElementById(viewId).classList.add('active');
+        this.currentView = viewId;
+        if (viewId === 'templates-list-view') this.renderTemplatesList();
+        if (viewId === 'filled-reports-list-view') this.renderFilledReports();
+    }
+
+    loadData() {
+        const templates = localStorage.getItem('report_templates');
+        const filled = localStorage.getItem('reports_filled');
+        const kpi = localStorage.getItem('reports_kpi');
+        this.db.templates = templates ? JSON.parse(templates) : [];
+        this.db.filledReports = filled ? JSON.parse(filled) : [];
+        this.db.kpiData = kpi ? JSON.parse(kpi) : [];
+        if (this.db.templates.length === 0) this.createDefaultTemplate();
+    }
+
+    saveData() {
+        localStorage.setItem('report_templates', JSON.stringify(this.db.templates));
+        localStorage.setItem('reports_filled', JSON.stringify(this.db.filledReports));
+        localStorage.setItem('reports_kpi', JSON.stringify(this.db.kpiData));
+    }
+
+    createDefaultTemplate() {
+        const defaultTemplate = {
+            id: `template-${Date.now()}`,
+            name: 'Plantilla Básica',
+            blocks: [
+                {
+                    id: `block-${Date.now()}-1`,
+                    name: 'Notas Generales',
+                    type: 'text',
+                    collapsed: false,
+                    items: [
+                        { id: `item-${Date.now()}-1`, name: 'Nota', type: 'note' }
+                    ]
+                }
+            ]
+        };
+        this.db.templates.push(defaultTemplate);
+        this.saveData();
+    }
+
+    renderTemplatesList() {
+        const grid = document.getElementById('templates-grid');
+        grid.innerHTML = '';
+        if (this.db.templates.length === 0) {
+            grid.innerHTML = '<p>Aún no hay plantillas.</p>';
+            return;
+        }
+        this.db.templates.forEach(t => {
+            const card = document.createElement('div');
+            card.className = 'card';
+            card.innerHTML = `
+                <h3>${t.name}</h3>
+                <div class="card-actions">
+                    <button class="btn btn-primary" onclick="app.fillReport('${t.id}')">Llenar</button>
+                    <button class="btn btn-secondary" onclick="app.editTemplate('${t.id}')">Editar</button>
+                    <button class="btn btn-danger" onclick="app.deleteTemplate('${t.id}')">Eliminar</button>
+                </div>`;
+            grid.appendChild(card);
+        });
+    }
+
+    addBlockToEditor() {
+        const block = {
+            id: `block-${Date.now()}`,
+            name: 'Nuevo Bloque',
+            type: 'text',
+            collapsed: false,
+            items: []
+        };
+        document.getElementById('blocks-container').appendChild(this.createBlockElement(block));
+    }
+
+    editTemplate(id) {
+        const template = this.db.templates.find(t => t.id === id);
+        if (!template) return;
+        this.currentTemplateId = id;
+        document.getElementById('editor-title').innerText = 'Editar Plantilla';
+        document.getElementById('template-name').value = template.name;
+        const container = document.getElementById('blocks-container');
+        container.innerHTML = '';
+        template.blocks.forEach(b => container.appendChild(this.createBlockElement(b)));
+        this.showView('template-editor-view');
+    }
+
+    createBlockElement(blockData) {
+        const div = document.createElement('div');
+        div.className = 'block';
+        div.dataset.id = blockData.id;
+        div.dataset.type = blockData.type;
+        if (blockData.collapsed) div.classList.add('collapsed');
+
+        let itemTypeOptions = '<option value="">+ Añadir Ítem...</option>';
+        ['text','image','kpi','table','note'].forEach(typeKey => {
+            itemTypeOptions += `<option value="${typeKey}">${typeKey}</option>`;
+        });
+
+        div.innerHTML = `
+            <div class="block-header" onclick="app.toggleBlockCollapse(this.closest('.block'))">
+                <h4 class="block-name-display">${blockData.name}</h4>
+                <div class="block-header-controls">
+                    <input type="text" class="block-name-input" value="${blockData.name}" oninput="this.closest('.block').querySelector('.block-name-display').innerText = this.value;">
+                    <select onchange="app.addItemToBlock(this)">${itemTypeOptions}</select>
+                    <button class="btn btn-danger btn-sm" onclick="event.stopPropagation(); app.deleteBlock(this.closest('.block'))">Eliminar Bloque</button>
+                    <button class="block-collapse-btn">▼</button>
+                </div>
+            </div>
+            <div class="block-content items-container"></div>`;
+
+        const container = div.querySelector('.items-container');
+        blockData.items.forEach(i => container.appendChild(this.createItemElement(i)));
+        return div;
+    }
+
+    addItemToBlock(select) {
+        const type = select.value;
+        if (!type) return;
+        const container = select.closest('.block').querySelector('.items-container');
+        const item = { id: `item-${Date.now()}`, name: type.toUpperCase(), type };
+        container.appendChild(this.createItemElement(item));
+        select.value = '';
+    }
+
+    createItemElement(itemData) {
+        const div = document.createElement('div');
+        div.className = 'item item-full-width';
+        div.dataset.itemId = itemData.id;
+        div.dataset.itemType = itemData.type;
+        let content = `<input type="text" class="item-name-input" value="${itemData.name}">`;
+        if (itemData.type === 'note') content = `<textarea class="item-name-input">${itemData.name}</textarea>`;
+        div.innerHTML = `
+            <span class="item-type-badge">${itemData.type}</span>
+            ${content}
+            <div class="item-controls-editor">
+                <button class="btn btn-danger btn-sm" onclick="app.deleteItem(this.closest('.item'))">-</button>
+            </div>`;
+        return div;
+    }
+
+    deleteItem(div) { div.remove(); }
+    deleteBlock(div) { div.remove(); }
+
+    saveTemplate() {
+        const name = document.getElementById('template-name').value.trim();
+        if (!name) { this.showMessageBox('La plantilla necesita un nombre.','warning'); return; }
+        const blocks = [];
+        document.querySelectorAll('#blocks-container .block').forEach(b => {
+            const items = [];
+            b.querySelectorAll('.item').forEach(i => {
+                items.push({ id: i.dataset.itemId, name: i.querySelector('.item-name-input').value, type: i.dataset.itemType });
+            });
+            blocks.push({ id: b.dataset.id, name: b.querySelector('.block-name-input').value, type: 'text', collapsed: b.classList.contains('collapsed'), items });
+        });
+        if (this.currentTemplateId) {
+            const idx = this.db.templates.findIndex(t => t.id === this.currentTemplateId);
+            if (idx !== -1) this.db.templates[idx] = { id: this.currentTemplateId, name, blocks };
+        } else {
+            this.db.templates.push({ id: `template-${Date.now()}`, name, blocks });
+        }
+        this.saveData();
+        this.showView('templates-list-view');
+    }
+
+    toggleBlockCollapse(blockDiv) {
+        blockDiv.classList.toggle('collapsed');
+    }
+
+    deleteTemplate(id) {
+        this.db.templates = this.db.templates.filter(t => t.id !== id);
+        this.db.filledReports = this.db.filledReports.filter(r => r.templateId !== id);
+        this.saveData();
+        this.renderTemplatesList();
+    }
+
+    fillReport(templateId) {
+        const template = this.db.templates.find(t => t.id === templateId);
+        if (!template) return;
+        this.currentTemplateId = templateId;
+        document.getElementById('filler-title').innerText = `Llenando: ${template.name}`;
+        // reset general editable sections
+        document.getElementById('report-cover').innerHTML = '<h3>Portada del Reporte</h3><p>Escriba aquí la información inicial del reporte...</p>';
+        document.getElementById('kpi-input').value = '';
+        document.querySelector('#summary-table tbody').innerHTML = '<tr><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td></tr>';
+        document.getElementById('photo-input').value = '';
+        document.getElementById('photo-list').innerHTML = '';
+        this.currentPhotos = [];
+        document.getElementById('photo-input').onchange = (e) => this.handlePhotoUpload(e);
+        const container = document.getElementById('filler-blocks-container');
+        container.innerHTML = '';
+        template.blocks.forEach(block => {
+            const blockDiv = document.createElement('div');
+            blockDiv.className = 'block';
+            blockDiv.innerHTML = `<div class="block-header"><h4>${block.name}</h4></div><div class="block-content items-container"></div>`;
+            const itemContainer = blockDiv.querySelector('.items-container');
+            block.items.forEach(item => {
+                const itemDiv = document.createElement('div');
+                itemDiv.className = 'checklist-item item-full-width';
+                itemDiv.dataset.itemId = item.id;
+                itemDiv.dataset.itemType = item.type;
+                let control = `<input type="text" class="item-value">`;
+                if (item.type === 'note') control = `<textarea class="item-value"></textarea>`;
+                if (item.type === 'image') control = `<input type="file" class="item-value" accept="image/*">`;
+                if (item.type === 'kpi') control = `<input type="number" class="item-value">`;
+                if (item.type === 'table') control = `<textarea class="item-value"></textarea>`;
+                itemDiv.innerHTML = `<p><strong>${item.name}</strong></p>${control}`;
+                itemContainer.appendChild(itemDiv);
+            });
+            container.appendChild(blockDiv);
+        });
+        this.showView('report-filler-view');
+    }
+
+    saveFilledReport() {
+        const templateId = this.currentTemplateId;
+        const template = this.db.templates.find(t => t.id === templateId);
+        if (!template) return;
+        const itemsData = {};
+        template.blocks.forEach(block => {
+            block.items.forEach(item => {
+                const el = document.querySelector(`.checklist-item[data-item-id="${item.id}"] .item-value`);
+                if (el) itemsData[item.id] = el.value;
+            });
+        });
+        const cover = document.getElementById('report-cover').innerHTML;
+        const summaryRows = [];
+        document.querySelectorAll('#summary-table tbody tr').forEach(tr => {
+            const cells = Array.from(tr.cells).map(td => td.innerText.trim());
+            if (cells.some(c => c)) summaryRows.push(cells);
+        });
+        const newReport = {
+            id: `filled-${Date.now()}`,
+            templateId,
+            templateName: template.name,
+            sequentialNumber: this.db.filledReports.filter(r => r.templateId === templateId).length + 1,
+            itemsData,
+            cover,
+            summary: summaryRows,
+            photos: this.currentPhotos.slice(),
+            timestamp: Date.now()
+        };
+        this.db.filledReports.push(newReport);
+        const kpiInput = document.querySelector('#kpi-section input[type="number"]');
+        if (kpiInput && kpiInput.value) {
+            const val = parseFloat(kpiInput.value);
+            if (!isNaN(val)) {
+                this.db.kpiData.push(val);
+                this.updateChart();
+            }
+        }
+        this.saveData();
+        this.showView('filled-reports-list-view');
+    }
+
+    renderFilledReports() {
+        const container = document.getElementById('filled-reports-container');
+        container.innerHTML = '';
+        if (this.db.filledReports.length === 0) {
+            container.innerHTML = '<p>No hay reportes guardados.</p>';
+            return;
+        }
+        this.db.filledReports.sort((a,b) => b.timestamp - a.timestamp).forEach(rep => {
+            container.appendChild(this.createFilledReportCard(rep));
+        });
+    }
+
+    createFilledReportCard(report) {
+        const card = document.createElement('div');
+        card.className = 'card';
+        card.innerHTML = `
+            <h4>Reporte #${report.sequentialNumber}</h4>
+            <p><strong>Plantilla:</strong> ${report.templateName}</p>
+            <div class="card-actions">
+                <button class="btn btn-secondary" onclick="app.exportToPDF('${report.id}')">PDF</button>
+                <button class="btn btn-danger" onclick="app.deleteFilledReport('${report.id}')">Eliminar</button>
+            </div>`;
+        return card;
+    }
+
+    deleteFilledReport(id) {
+        this.db.filledReports = this.db.filledReports.filter(r => r.id !== id);
+        this.saveData();
+        this.renderFilledReports();
+    }
+
+    handlePhotoUpload(event) {
+        const list = document.getElementById('photo-list');
+        Array.from(event.target.files).forEach(file => {
+            const reader = new FileReader();
+            reader.onload = e => {
+                const img = document.createElement('img');
+                img.src = e.target.result;
+                img.className = 'photo-thumb';
+                list.appendChild(img);
+                this.currentPhotos.push(e.target.result);
+            };
+            reader.readAsDataURL(file);
+        });
+    }
+
+    formatValueForPDF(type, value) {
+        if (!value) return '';
+        return value;
+    }
+
+    exportToPDF(id) {
+        const report = this.db.filledReports.find(r => r.id === id);
+        const template = this.db.templates.find(t => t.id === report.templateId);
+        if (!report || !template) return;
+        const doc = new this.jsPDF();
+        doc.setFontSize(18);
+        doc.text(`Reporte: ${template.name} (#${report.sequentialNumber})`, 14, 22);
+        doc.setFontSize(11);
+        doc.setTextColor(100);
+        let yPos = 35;
+        // Cover section
+        doc.setFontSize(14);
+        doc.setFont(undefined, 'bold');
+        doc.text('Portada', 14, yPos);
+        doc.setFont(undefined, 'normal');
+        yPos += 7;
+        const coverText = report.cover.replace(/<[^>]+>/g, '');
+        const split = doc.splitTextToSize(coverText, 180);
+        doc.text(split, 14, yPos);
+        yPos += split.length * 6 + 4;
+        template.blocks.forEach(block => {
+            doc.setFontSize(14);
+            doc.setFont(undefined, 'bold');
+            doc.text(block.name, 14, yPos);
+            yPos += 7;
+            const tableBody = block.items.map(item => {
+                const value = report.itemsData[item.id] || '';
+                return [ item.name, this.formatValueForPDF(item.type, value) ];
+            });
+            doc.autoTable({ startY: yPos, head: [['Ítem','Valor']], body: tableBody, styles:{fontSize:9, cellPadding:2}, headStyles:{fillColor:[44,62,80], textColor:[255,255,255], fontStyle:'bold'}, alternateRowStyles:{fillColor:[240,240,240]}, margin:{left:14, right:14} });
+            yPos = doc.autoTable.previous.finalY + 10;
+            if (yPos > 260) { doc.addPage(); yPos = 20; }
+        });
+
+        // Summary table
+        if (report.summary && report.summary.length) {
+            doc.setFontSize(14);
+            doc.setFont(undefined, 'bold');
+            doc.text('Resumen Semanal', 14, yPos);
+            yPos += 7;
+            doc.autoTable({ startY: yPos, head: [['Actividad','Estado','Notas']], body: report.summary, styles:{fontSize:9, cellPadding:2}, headStyles:{fillColor:[44,62,80], textColor:[255,255,255], fontStyle:'bold'}, margin:{left:14,right:14} });
+            yPos = doc.autoTable.previous.finalY + 10;
+        }
+
+        // Photos
+        if (report.photos && report.photos.length) {
+            doc.setFontSize(14);
+            doc.setFont(undefined, 'bold');
+            doc.text('Fotografías', 14, yPos);
+            yPos += 5;
+            report.photos.forEach((imgData, idx) => {
+                if (yPos > 250) { doc.addPage(); yPos = 20; }
+                doc.addImage(imgData, 'PNG', 14, yPos, 60, 45);
+                yPos += 50;
+            });
+        }
+        if (this.db.kpiData.length) {
+            const canvas = document.createElement('canvas');
+            new Chart(canvas.getContext('2d'), { type:'line', data:{ labels:this.db.kpiData.map((_,i)=>`Semana ${i+1}`), datasets:[{label:'KPI', data:this.db.kpiData, borderColor:'#3498db'}] } });
+            doc.addPage();
+            doc.text('Histórico KPI', 14, 22);
+            doc.addImage(canvas.toDataURL('image/png'), 'PNG', 14, 30, 180, 80);
+        }
+        doc.save(`${template.name}_${report.sequentialNumber}.pdf`);
+    }
+
+    showMessageBox(msg, type='info') {
+        const box = document.createElement('div');
+        box.className = `message-box ${type}`;
+        box.innerText = msg;
+        document.body.appendChild(box);
+        setTimeout(()=>{ box.style.opacity = 1; }, 10);
+        setTimeout(()=>{ box.style.opacity = 0; box.addEventListener('transitionend', () => box.remove()); }, 3000);
+    }
+
+    updateChart() {
+        const ctx = document.getElementById('kpi-chart').getContext('2d');
+        if (window.kpiChart) window.kpiChart.destroy();
+        window.kpiChart = new Chart(ctx, {
+            type: 'line',
+            data: {
+                labels: this.db.kpiData.map((_,i)=>`Semana ${i+1}`),
+                datasets: [{ label:'KPI', data:this.db.kpiData, borderColor:'#3498db' }]
+            }
+        });
+    }
+}
+
+const app = new ReportApp();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Reportes de Avance</title>
+    <link rel="manifest" href="manifest.json">
+    <link rel="stylesheet" href="style.css">
+    <!-- Librerías para exportar a PDF y gráficos -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.23/jspdf.plugin.autotable.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+
+    <div class="container">
+        <header class="header">
+            <h1>Reportes de Avance</h1>
+            <p>Herramienta para crear y gestionar reportes</p>
+        </header>
+
+        <!-- Vista Principal (Menú) -->
+        <div id="home-view" class="view active">
+            <div id="home-menu">
+                <h2>Menú Principal</h2>
+                <button class="btn btn-primary" onclick="app.showView('templates-list-view')">📝 Gestionar Plantillas</button>
+                <button class="btn btn-primary" onclick="app.showView('filled-reports-list-view')">📋 Ver Reportes</button>
+            </div>
+        </div>
+
+        <!-- Vista: Lista de Plantillas -->
+        <div id="templates-list-view" class="view">
+            <button class="btn btn-secondary back-button" onclick="app.showView('home-view')">‹ Volver al Menú</button>
+            <h2>Mis Plantillas</h2>
+            <hr>
+            <div id="templates-grid" class="card-grid"></div>
+        </div>
+
+        <!-- Vista: Editor de Plantillas -->
+        <div id="template-editor-view" class="view">
+            <button class="btn btn-secondary back-button" onclick="app.showView('templates-list-view')">‹ Volver a Plantillas</button>
+            <h2 id="editor-title">Crear Nueva Plantilla</h2>
+            <div class="form-group">
+                <label for="template-name">Nombre de la Plantilla</label>
+                <input type="text" id="template-name" placeholder="Ej: Reporte Semanal">
+            </div>
+            <div id="blocks-container" ondrop="app.handleBlockDrop(event)" ondragover="app.handleBlockDragOver(event)"></div>
+            <div style="margin-bottom: 20px;">
+                <button class="btn btn-add" onclick="app.addBlockToEditor()">+ Añadir Bloque</button>
+            </div>
+            <hr>
+            <button class="btn btn-primary" onclick="app.saveTemplate()">Guardar Plantilla</button>
+        </div>
+
+        <!-- Vista: Lista de Reportes Llenados -->
+        <div id="filled-reports-list-view" class="view">
+            <button class="btn btn-secondary back-button" onclick="app.showView('home-view')">‹ Volver al Menú</button>
+            <h2>Reportes Guardados</h2>
+            <div id="filled-reports-container"></div>
+        </div>
+
+        <!-- Vista: Llenar un Reporte -->
+        <div id="report-filler-view" class="view">
+            <button class="btn btn-secondary back-button" onclick="app.showView('filled-reports-list-view')">‹ Cancelar y Volver</button>
+            <h2 id="filler-title">Llenando Reporte</h2>
+
+            <section id="report-cover" class="card" contenteditable="true">
+                <h3>Portada del Reporte</h3>
+                <p>Escriba aquí la información inicial del reporte...</p>
+            </section>
+
+            <section id="kpi-section" class="card">
+                <h3>Indicadores</h3>
+                <input type="number" id="kpi-input" placeholder="Avance semanal" min="0" max="100">
+                <canvas id="kpi-chart" height="100"></canvas>
+            </section>
+
+            <section id="summary-section" class="card">
+                <h3>Resumen Semanal</h3>
+                <table id="summary-table">
+                    <thead>
+                        <tr><th>Actividad</th><th>Estado</th><th>Notas</th></tr>
+                    </thead>
+                    <tbody>
+                        <tr><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td></tr>
+                    </tbody>
+                </table>
+            </section>
+
+            <section id="photos-section" class="card">
+                <h3>Fotografías</h3>
+                <input type="file" id="photo-input" multiple accept="image/*">
+                <div id="photo-list"></div>
+            </section>
+
+            <div id="filler-blocks-container"></div>
+            <hr>
+            <button class="btn btn-primary" onclick="app.saveFilledReport()">Guardar Reporte</button>
+        </div>
+
+    </div>
+
+    <script src="app.js"></script>
+</body>
+</html>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,9 @@
+{
+    "name": "Reporte de Avance",
+    "short_name": "Reporte",
+    "start_url": "./index.html",
+    "display": "standalone",
+    "background_color": "#ffffff",
+    "theme_color": "#3498db",
+    "icons": []
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,224 @@
+:root {
+    --primary-color: #2c3e50;
+    --secondary-color: #3498db;
+    --light-gray: #ecf0f1;
+    --medium-gray: #bdc3c7;
+    --dark-gray: #7f8c8d;
+    --white: #ffffff;
+    --red: #e74c3c;
+    --green: #2ecc71;
+    --yellow: #f1c40f;
+    --font-family: 'Inter', sans-serif;
+}
+
+body {
+    font-family: var(--font-family);
+    margin: 0;
+    background-color: var(--light-gray);
+    color: var(--primary-color);
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    min-height: 100vh;
+    padding: 20px;
+    box-sizing: border-box;
+}
+
+.container {
+    width: 100%;
+    max-width: 1000px;
+    background: var(--white);
+    border-radius: 12px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+    overflow: hidden;
+}
+
+.header {
+    background: var(--primary-color);
+    color: var(--white);
+    padding: 20px;
+    text-align: center;
+}
+
+.header h1 {
+    margin: 0;
+    font-size: 1.8em;
+}
+.header p {
+    margin: 5px 0 0;
+    opacity: 0.8;
+}
+
+.view {
+    display: none;
+    padding: 25px;
+    animation: fadeIn 0.5s ease-in-out;
+    padding-bottom: 50px;
+}
+.view.active {
+    display: block;
+}
+@keyframes fadeIn {
+    from { opacity: 0; transform: translateY(10px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+.btn, select {
+    color: var(--white);
+    border: none;
+    padding: 12px 20px;
+    border-radius: 8px;
+    cursor: pointer;
+    font-size: 1em;
+    font-weight: bold;
+    text-transform: uppercase;
+    transition: background 0.3s, transform 0.2s;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+.btn { background: var(--secondary-color); }
+select {
+    background: var(--dark-gray);
+    color: white;
+    padding: 12px;
+}
+
+.btn:hover {
+    background: #2980b9;
+    transform: translateY(-2px);
+}
+.btn-primary { background: var(--secondary-color); }
+.btn-danger { background: var(--red); }
+.btn-danger:hover { background: #c0392b; }
+.btn-secondary { background: var(--dark-gray); }
+.btn-secondary:hover { background: #6c7a89; }
+.btn-add { background: var(--green); }
+.btn-add:hover { background: #27ae60; }
+.btn-sm { padding: 8px 12px; font-size: 0.8em; }
+
+.card-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 20px; }
+.card { background: #f9f9f9; border: 1px solid #e0e0e0; border-radius: 8px; padding: 20px; box-shadow: 0 2px 5px rgba(0,0,0,0.05); display: flex; flex-direction: column; gap: 15px; }
+.card h3, .card h4 { margin: 0; font-size: 1.2em; color: var(--primary-color); }
+.card-actions { display: flex; gap: 10px; margin-top: auto; flex-wrap: wrap; }
+
+.form-group { margin-bottom: 20px; }
+.form-group label { display: block; font-weight: bold; margin-bottom: 8px; color: var(--primary-color); }
+.form-group input, .form-group textarea, .form-group select { width: 100%; padding: 12px; border: 1px solid var(--medium-gray); border-radius: 8px; font-size: 1em; box-sizing: border-box; transition: border-color 0.3s, box-shadow 0.3s; }
+.form-group input:focus, .form-group textarea:focus, .form-group select:focus { outline: none; border-color: var(--secondary-color); box-shadow: 0 0 0 3px rgba(52, 152, 219, 0.2); }
+
+.block { background: var(--white); border: 1px solid var(--medium-gray); border-radius: 12px; padding: 20px; margin-bottom: 20px; overflow: hidden; box-shadow: 0 2px 8px rgba(0,0,0,0.08); }
+.block-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 15px; padding-bottom: 10px; border-bottom: 1px solid var(--light-gray); flex-wrap: wrap; gap: 10px; cursor: pointer; }
+.block-header h4 { margin: 0; font-size: 1.3em; color: var(--primary-color); flex-grow: 1; }
+.block-header-controls { display: flex; align-items: center; gap: 10px; }
+.block-collapse-btn { background: none; border: none; color: var(--primary-color); font-size: 1.5em; cursor: pointer; padding: 0 5px; transition: transform 0.2s ease-in-out; }
+.block.collapsed .block-collapse-btn { transform: rotate(-90deg); }
+.block-content { max-height: 2000px; overflow: hidden; transition: max-height 0.3s ease-out, padding 0.3s ease-out; padding-top: 5px; }
+.block.collapsed .block-content { max-height: 0; padding-top: 0; }
+
+.items-container { display: flex; flex-wrap: wrap; gap: 15px; align-items: flex-start; }
+.item { background: #fdfdfd; border: 1px solid #eee; border-radius: 8px; padding: 15px; box-shadow: 0 1px 3px rgba(0,0,0,0.05); display: flex; flex-direction: column; gap: 10px; position: relative; min-height: 80px; box-sizing: border-box; }
+.item.item-small-group { flex: 1 1 calc(33.333% - 15px); min-width: 250px; }
+.item.item-medium-group { flex: 1 1 calc(50% - 10px); min-width: 350px; }
+.item.item-full-width { flex: 1 1 100%; }
+.item.item-tall { min-height: 120px; }
+.item.item-tall textarea { min-height: 80px; resize: vertical; }
+.item[data-item-type="nota_general"] textarea { min-height: 70px; }
+
+.item .item-type-badge { background: var(--dark-gray); color: white; padding: 4px 8px; border-radius: 4px; font-size: 0.8em; white-space: nowrap; }
+.item .item-name-input { flex-grow: 1; font-weight: bold; color: var(--primary-color); border: 1px solid var(--light-gray); border-radius: 4px; padding: 8px; }
+.item-controls-editor { display: flex; gap: 5px; align-items: center; justify-content: flex-end; margin-top: auto; }
+
+.drag-handle { position: absolute; top: 5px; left: 5px; cursor: grab; color: var(--medium-gray); font-size: 0.8em; padding: 5px; border-radius: 4px; transition: color 0.2s; }
+.item:hover .drag-handle { color: var(--primary-color); }
+.item.dragging { opacity: 0.5; border: 2px dashed var(--secondary-color); }
+.block-drag-handle { position: relative; margin-right: 10px; cursor: grab; }
+
+.item.item-quality { border-left: 5px solid var(--yellow); }
+.item.item-aprobacion { border-left: 5px solid var(--green); }
+.item.item-comments { border-left: 5px solid var(--dark-gray); }
+.item.item-media { border-left: 5px solid var(--secondary-color); }
+.item.item-signature { border-left: 5px solid #8e44ad; }
+
+.checklist-item { padding: 15px; border-radius: 8px; margin-bottom: 15px; background: #fdfdfd; border: 1px solid #eee; box-shadow: 0 1px 3px rgba(0,0,0,0.05); box-sizing: border-box; }
+.item-controls { margin-top: 10px; }
+.item-status { display: flex; gap: 15px; align-items: center; flex-wrap: wrap; }
+.item-status label { cursor: pointer; display: flex; align-items: center; gap: 5px; }
+.item-status input[type="radio"] { accent-color: var(--secondary-color); }
+.general-data-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(250px, 1fr)); gap: 15px; background: #f9f9f9; padding: 20px; border-radius: 8px; margin-bottom: 25px; }
+
+.filler-items-container { display: flex; flex-wrap: wrap; gap: 15px; align-items: flex-start; }
+.filler-item-row { display: flex; flex-wrap: wrap; gap: 15px; width: 100%; }
+.filler-item-row > div { flex: 1 1 calc(33.333% - 15px); min-width: 250px; box-sizing: border-box; }
+.filler-item-row > .checklist-item.item-medium-group { flex: 1 1 calc(50% - 7.5px); min-width: 350px; }
+.filler-item-row > .checklist-item.item-full-width { flex: 1 1 100%; }
+
+.checklist-item input[type="text"],
+.checklist-item input[type="date"],
+.checklist-item input[type="number"],
+.checklist-item textarea {
+    width: 100%;
+    padding: 10px;
+    border: 1px solid var(--medium-gray);
+    border-radius: 6px;
+    font-size: 1em;
+    box-sizing: border-box;
+}
+.checklist-item textarea { min-height: 80px; resize: vertical; }
+.checklist-item[data-item-type="nota_general"] textarea { min-height: 70px; }
+
+.signature-container { display: flex; flex-direction: column; align-items: center; gap: 5px; padding-top: 10px; margin-bottom: 10px; min-height: 80px; justify-content: flex-end; }
+.signature-space { width: 100%; height: 50px; border: 1px dashed var(--medium-gray); border-radius: 4px; margin-bottom: 10px; display: flex; align-items: center; justify-content: center; color: var(--dark-gray); font-size: 0.9em; text-align: center; line-height: 1.2; padding: 5px; }
+.signature-container input.item-value { border: none; border-bottom: 1px solid var(--primary-color); text-align: center; padding: 5px 0; background: transparent; font-weight: bold; }
+.signature-container label { font-size: 0.8em; color: var(--dark-gray); margin-top: 5px; }
+
+.residente-editor-inputs { display: flex; gap: 10px; flex-wrap: wrap; width: 100%; }
+.residente-editor-inputs .item-puesto-editor { flex: 1; min-width: 80px; font-size: 0.9em; }
+.residente-editor-inputs .item-nombre-editor { flex: 2; min-width: 120px; font-size: 1em; font-weight: bold; }
+.residente-inputs { display: flex; flex-direction: column; gap: 5px; width: 100%; }
+.filler-item-row > .checklist-item[data-item-type="residente_name"] .residente-inputs { flex-direction: row; align-items: baseline; gap: 10px; }
+.residente-inputs .item-value-sub { font-size: 0.9em; flex: 1; min-width: 80px; }
+.residente-inputs .item-value-main { font-size: 1.1em; font-weight: bold; flex: 2; min-width: 120px; }
+
+.image-upload-wrapper { border: 2px dashed var(--medium-gray); border-radius: 8px; padding: 20px; text-align: center; cursor: pointer; background-color: var(--light-gray); display: flex; flex-direction: column; align-items: center; justify-content: center; min-height: 150px; transition: border-color 0.3s; }
+.image-upload-wrapper:hover { border-color: var(--secondary-color); }
+.image-upload-wrapper img { max-width: 100%; max-height: 200px; margin-top: 10px; border-radius: 8px; object-fit: contain; }
+.image-upload-wrapper input[type="file"] { display: none; }
+.image-upload-label { font-size: 1em; color: var(--dark-gray); display: block; margin-top: 10px; }
+
+.progress-bar { width: 100%; height: 10px; background-color: var(--light-gray); border-radius: 5px; overflow: hidden; margin-top: 5px; }
+.progress-bar-fill { height: 100%; background-color: var(--secondary-color); border-radius: 5px; transition: width 0.5s; }
+.status-light { width: 15px; height: 15px; border-radius: 50%; display: inline-block; margin-right: 8px; }
+.status-light.green { background-color: var(--green); }
+.status-light.yellow { background-color: var(--yellow); }
+.status-light.red { background-color: var(--red); }
+
+.back-button { margin-bottom: 20px; }
+#home-menu { display: flex; flex-direction: column; gap: 20px; align-items: center; }
+
+.message-box, .confirm-box-overlay { font-family: var(--font-family); }
+.message-box { position: fixed; top: 20px; left: 50%; transform: translateX(-50%); color: white; padding: 15px 25px; border-radius: 8px; box-shadow: 0 5px 15px rgba(0,0,0,0.2); z-index: 1000; opacity: 0; transition: opacity 0.3s ease-in-out; font-size: 1em; }
+.message-box.info { background-color: var(--primary-color); }
+.message-box.success { background-color: var(--green); }
+.message-box.error { background-color: var(--red); }
+.message-box.warning { background-color: var(--yellow); color: var(--primary-color); }
+
+.confirm-box-overlay { position: fixed; top: 0; left: 0; width: 100%; height: 100%; background-color: rgba(0,0,0,0.6); z-index: 1000; display: flex; align-items: center; justify-content: center; }
+.confirm-box { background-color: white; padding: 30px; border-radius: 12px; box-shadow: 0 10px 30px rgba(0,0,0,0.3); z-index: 1001; text-align: center; max-width: 400px; width: 90%; }
+.confirm-box p { font-size: 1.1em; margin-bottom: 25px; color: var(--primary-color); }
+.confirm-box div { display: flex; justify-content: center; gap: 15px; }
+
+/* Photo previews */
+#photo-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-top: 10px;
+}
+.photo-thumb {
+    width: 120px;
+    height: 90px;
+    object-fit: cover;
+    border: 1px solid var(--medium-gray);
+    border-radius: 4px;
+}


### PR DESCRIPTION
## Summary
- add HTML interface for creating and viewing reports
- style page with responsive card layout
- implement basic template and report management in JS
- save data to localStorage and create PDF export
- provide manifest for future PWA support

## Testing
- `npm test` *(fails: Could not find package.json)*
- `pytest` *(no tests discovered)*

------
https://chatgpt.com/codex/tasks/task_e_684c8aea0d4083269d6e499f2370b799